### PR TITLE
处理当音频播放异常情况

### DIFF
--- a/src/js/weixinAudio.js
+++ b/src/js/weixinAudio.js
@@ -16,6 +16,7 @@
 			this.$audio_progress = $context.find('#audio_progress');
 			//属性
 			this.currentState = 'pause';
+			this.audiocurrentTime = 0;
 			this.time = null;
 			this.settings = $.extend(true, defaultoptions, options);
 			//执行初始化
@@ -86,6 +87,16 @@
 				var styles = {
 					"width": percentage
 				};
+				
+				//当音频播放异常，暂停播放
+				if (this.audiocurrentTime == self.Audio.currentTime && this.audiocurrentTime!=0) {
+				    self.Audio.currentTime = 0;
+				    self.pause();
+				    self.Audio.load();
+				}
+
+				this.audiocurrentTime = self.Audio.currentTime;
+				
 				self.$audio_progress.css(styles);
 			},
 			//获取时间秒


### PR DESCRIPTION
当音频异常情况，播放结束时，self.Audio.ended一直为false,播放状态一直处于播放状态，但没有声音。